### PR TITLE
Update SpecialVstDevices.java

### DIFF
--- a/src/main/java/com/allenheath/k2/set1/SpecialVstDevices.java
+++ b/src/main/java/com/allenheath/k2/set1/SpecialVstDevices.java
@@ -6,8 +6,8 @@ import com.bitwig.extension.controller.api.DeviceMatcher;
 import com.bitwig.extension.controller.api.SpecificPluginDevice;
 
 public enum SpecialVstDevices implements SpecialDevice {
-	LEXICON_PSP(1347630130);
-
+	//LEXICON_PSP(1347630130); Disabling the old Lexicon_PSP42 otherwise Lexicon_PSP42x 2.0.2 will not work, or the compiling will crash
+;
 	private final int id;
 
 	private SpecialVstDevices(final int id) {


### PR DESCRIPTION
//LEXICON_PSP(1347630130); Disabling the old Lexicon_PSP42 otherwise Lexicon_PSP42x 2.0.2 will not work, or the compiling will crash